### PR TITLE
Add leading zeros to date formats

### DIFF
--- a/lib/elapsed_time.dart
+++ b/lib/elapsed_time.dart
@@ -73,7 +73,7 @@ class TimeElapsed extends PolymerElement {
   /*
    * the format used to present the date in the tooltip
    */
-  @published String tooltipFormat = 'yyyy-MM-dd H:m:s';
+  @published String tooltipFormat = 'yyyy-MM-dd H:mm:ss';
   
 /*
  * Callback which supplies CSS style for the time elapse display.


### PR DESCRIPTION
A date like 11:3:24 doesn't look good. Therefore add a leading zero to minutes and seconds.
