### PR TITLE
Handle dateTime is null and changes to dateTime

### DIFF
--- a/lib/elapsed_time.dart
+++ b/lib/elapsed_time.dart
@@ -136,6 +136,10 @@ class TimeElapsed extends PolymerElement {
     new _RefreshTimer.seconds(refreshInSeconds).unregister(this);
   }  
   
+  void dateTimeChanged() {
+    refreshDates();
+  }
+  
   void refreshDates([Timer timer]) {
     if (dateTime != null) {
       var isVerbose = "true" == verbose;


### PR DESCRIPTION
If the dateTime is null, don't display anything. If the dateTime object is changed, don't wait until the timer is tirggered but update is intermediately.
